### PR TITLE
[test] make test for mail_sender to do tdd

### DIFF
--- a/mail_sender.py
+++ b/mail_sender.py
@@ -1,0 +1,18 @@
+class MailSender:
+    def __init__(self, baseDir='', source='', new_filename=''):
+        self.baseDir = baseDir
+        self.source = source
+        self.new_filename = new_filename
+        self.newFilePath = ''
+
+    def get_recipients_from_excel(self, sheet, pickUpCol):
+        pass
+
+    def remove_columns_and_save(self, sheet, workbook, removeCols):
+        pass
+
+    def send_mail(self, recipientList):
+        pass
+
+    def execute(self):
+        pass

--- a/test_mail_sender.py
+++ b/test_mail_sender.py
@@ -1,0 +1,36 @@
+import pytest
+from mail_sender import MailSender
+
+
+@pytest.fixture
+def mail_sender():
+    return MailSender(baseDir='dummy_dir', source='source.xlsx', new_filename='modified.xlsx')
+
+
+def test_send_mail(mocker, mail_sender):
+    mock_post = mocker.patch('mail_sender.requests.post')
+    mock_post.return_value.json.return_value = {"result": "success"}
+
+    recipients = [{'emailAddress': 'test@samsung.com', 'recipientType': 'TO'}]
+
+    mail_sender.newFilePath = ''
+    mail_sender.send_mail(recipients)
+
+    mock_post.assert_called_once()
+
+
+def test_execute(mocker, mail_sender):
+    mocker.patch.object(mail_sender, 'get_recipients_from_excel')
+    mocker.patch.object(mail_sender, 'remove_columns_and_save')
+    mocker.patch.object(mail_sender, 'send_mail')
+
+    mock_dispatch = mocker.patch('mail_sender.win32.Dispatch')
+    mock_excel = mocker.Mock()
+    mock_dispatch.return_value = mock_excel
+    mock_excel.Workbooks.Open.return_value = mocker.Mock(Sheets={2: mocker.Mock()})
+
+    mail_sender.execute()
+
+    assert mail_sender.get_recipients_from_excel.called
+    assert mail_sender.remove_columns_and_save.called
+    assert mail_sender.send_mail.called


### PR DESCRIPTION
구현하고자 하는 것: 멘토, 멘티 정보가 들어있는 멘토링 엑셀 파일을 받아 재 가공하여 멘토비 사용 기록을 할 수 있는 새로운 파일을 만들고, 이를 첨부하여 멘토들에게 메일을 보내는 기능.

mail_sender.py의 골조를 짜고 구현하고자 하는 기능에 대해 test를 구현하였습니다. (tdd red단계) 